### PR TITLE
Updates for multi project usage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -390,7 +390,7 @@ logs/fortio-mcp:
 
 # Show MCP logs
 logs-mcp:
-	gcloud --project ${PROJECT_ID} logging read \
+	gcloud --project ${CONFIG_PROJECT_ID} logging read \
     	   --format "csv(textPayload,jsonPayload.message)" \
     		--freshness 1h \
      		'resource.type="istio_control_plane"'
@@ -437,7 +437,7 @@ cas/setup-k8s:
 cas/cert:
 	gcloud privateca certificates create \
         --issuer-pool mesh --issuer-location ${REGION} \
-        --subject "CN=${PROJECTI_ID},O=${PROJECT_ID}" \
+        --subject "CN=${PROJECT_ID},O=${PROJECT_ID}" \
         --generate-key \
         --key-output-file key.pem \
         --cert-output-file cert.pem

--- a/manifests/google-service-account-template.yaml
+++ b/manifests/google-service-account-template.yaml
@@ -26,16 +26,16 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: WorkloadGroup
 metadata:
-  name: gsa-${CONFIG_PROJECT_ID}
+  name: gsa-${PROJECT_ID}
   namespace: ${WORKLOAD_NAMESPACE}
 spec:
   metadata:
     labels:
-      cr-google-service-account: "k8s-${WORKLOAD_NAMESPACE}.${CONFIG_PROJECT_ID}"
+      cr-google-service-account: "k8s-${WORKLOAD_NAMESPACE}.${PROJECT_ID}"
     annotations:
       security.cloud.google.com/IdentityProvider: google
   template:
-    serviceAccount: k8s-${WORKLOAD_NAMESPACE}@${CONFIG_PROJECT_ID}.iam.gserviceaccount.com
+    serviceAccount: k8s-${WORKLOAD_NAMESPACE}@${PROJECT_ID}.iam.gserviceaccount.com
 ---
 
 # This config allows a Google Service Account to impersonate a Kubernetes Service Account by
@@ -49,7 +49,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   namespace: ${WORKLOAD_NAMESPACE}
-  name: gsa-${CONFIG_PROJECT_ID}
+  name: gsa-${PROJECT_ID}
 rules:
   # Allows 'downscoping' - getting tokens with audience - without mounting.
   - apiGroups: [ "" ]
@@ -89,7 +89,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: gsa-${CONFIG_PROJECT_ID}
+  name: gsa-${PROJECT_ID}
 subjects:
   - kind: User
     name: k8s-${WORKLOAD_NAMESPACE}@${PROJECT_ID}.iam.gserviceaccount.com

--- a/samples/fortio/Makefile
+++ b/samples/fortio/Makefile
@@ -150,7 +150,7 @@ setup-wi:
     # Map the KSA to the GSA (Workload identity)
 	gcloud iam service-accounts add-iam-policy-binding \
 		--role roles/iam.workloadIdentityUser \
-		--member "serviceAccount:${PROJECT_ID}.svc.id.goog[${WORKLOAD_NAMESPACE}/default]" \
+		--member "serviceAccount:${CONFIG_PROJECT_ID}.svc.id.goog[${WORKLOAD_NAMESPACE}/default]" \
 		k8s-${WORKLOAD_NAMESPACE}@${PROJECT_ID}.iam.gserviceaccount.com
 	# K8S side of the mapping.
 	kubectl annotate serviceaccount \
@@ -159,10 +159,10 @@ setup-wi:
     # At this point, Pods running as default KSA can test:
 	# curl -H "Metadata-Flavor: Google" http://169.254.169.254/computeMetadata/v1/instance/service-accounts/
 
-setup-hgate: PROJECT_NUMBER=$(shell gcloud projects describe ${PROJECT_ID} --format="value(projectNumber)")
+setup-hgate: PROJECT_NUMBER=$(shell gcloud projects describe ${CONFIG_PROJECT_ID} --format="value(projectNumber)")
 setup-hgate:
 	gcloud run services add-iam-policy-binding ${SERVICE} \
-      --member="serviceAccount:${PROJECT_ID}.svc.id.goog[istio-system/default]" \
+      --member="serviceAccount:${CONFIG_PROJECT_ID}.svc.id.goog[istio-system/default]" \
       --role='roles/run.invoker'
 	gcloud run services add-iam-policy-binding ${SERVICE} \
       --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-meshdataplane.iam.gserviceaccount.com" \
@@ -184,8 +184,8 @@ setup-sni:
 
 cleanup:
 	kubectl delete ns ${WORKLOAD_NAMESPACE} || true
-	gcloud --project ${PROJECT_ID} projects remove-iam-policy-binding \
-            ${PROJECT_ID} \
+	gcloud --project ${CONFIG_PROJECT_ID} projects remove-iam-policy-binding \
+            ${CONFIG_PROJECT_ID} \
             --member="serviceAccount:k8s-${WORKLOAD_NAMESPACE}@${PROJECT_ID}.iam.gserviceaccount.com" \
             --role="roles/container.clusterViewer" || true
 	gcloud --project ${PROJECT_ID} iam service-accounts -q delete k8s-${WORKLOAD_NAMESPACE}@${PROJECT_ID}.iam.gserviceaccount.com || true


### PR DESCRIPTION
Usage of CONFIG_PROJECT_ID in the README.

Corrected some inconsistencies in the project specified for Workload Identity.
- The Namespace GSA should be created in PROJECT_ID along with the Cloud Run resources
- The Workload Identity pool should always be in CONFIG_PROJECT_ID